### PR TITLE
Fix errant notification on relog

### DIFF
--- a/src/main/java/dev/blonks/kitchenrunning/KitchenRunningPlugin.java
+++ b/src/main/java/dev/blonks/kitchenrunning/KitchenRunningPlugin.java
@@ -85,6 +85,13 @@ public class KitchenRunningPlugin extends Plugin
         hooks.unregisterRenderableDrawListener(renderableDrawListener);
     }
 
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged e) {
+		if (e.getGameState() == GameState.LOGIN_SCREEN) {
+			updateState();
+		}
+	}
+
     @Subscribe
     public void onGameTick(GameTick e) {
 		updateState();


### PR DESCRIPTION
Fix errant notification when the user relogs by refreshing state variables when game state changes

Closes #11 